### PR TITLE
Include value in validation failure message for AddressEncoder

### DIFF
--- a/eth_abi/encoding.py
+++ b/eth_abi/encoding.py
@@ -451,8 +451,8 @@ class AddressEncoder(Fixed32ByteSizeEncoder):
     def validate_value(cls, value):
         if not is_address(value):
             raise EncodingTypeError(
-                "Cannot encode value {0} of type {1} as an address using {2}".format(
-                    value,
+                "Cannot encode value {0} of type {1} using {2}".format(
+                    repr(value),
                     type(value),
                     cls.__name__,
                 )

--- a/eth_abi/encoding.py
+++ b/eth_abi/encoding.py
@@ -451,7 +451,8 @@ class AddressEncoder(Fixed32ByteSizeEncoder):
     def validate_value(cls, value):
         if not is_address(value):
             raise EncodingTypeError(
-                "Value of type {0} cannot be encoded by {1}".format(
+                "Cannot encode value {0} of type {1} as an address using {2}".format(
+                    value,
                     type(value),
                     cls.__name__,
                 )


### PR DESCRIPTION
### What was wrong?

Fixes #101 

### How was it fixed?

It was suggested that we have a different message for `str` ([see here](https://github.com/ethereum/eth-abi/issues/101#issuecomment-429482386)), but that doesn't solve the issue described because the message still implies that the type is the issue when `bytes` is passed. Since `is_address` is just a boolean check and doesn't give context to what the failure was (i.e. malformed data vs. invalid type), I think the only solution here is to just include the value in the message and the consumer should at least have more context to deduce why the failure occurred. @pipermerriam, what are your thoughts? If these changes look good, I'm assuming we'd want a backport to 1.x?

#### Cute Animal Picture

![Cute animal picture](https://static.boredpanda.com/blog/wp-content/uploads/2017/05/cute-baby-hippos-fb.png)