### PR TITLE
perf: replace curried padding helpers with direct functions

### DIFF
--- a/eth_abi/utils/padding.py
+++ b/eth_abi/utils/padding.py
@@ -1,28 +1,22 @@
-from eth_utils.toolz import (
-    curry,
-)
-
-
-# typing ignored because toolz do not provide typing info
-@curry  # type: ignore
 def zpad(value: bytes, length: int) -> bytes:
     return value.rjust(length, b"\x00")
 
 
-zpad32 = zpad(length=32)
+def zpad32(value: bytes) -> bytes:
+    return zpad(value, length=32)
 
 
-@curry  # type: ignore
 def zpad_right(value: bytes, length: int) -> bytes:
     return value.ljust(length, b"\x00")
 
 
-zpad32_right = zpad_right(length=32)
+def zpad32_right(value: bytes) -> bytes:
+    return zpad_right(value, length=32)
 
 
-@curry  # type: ignore
 def fpad(value: bytes, length: int) -> bytes:
     return value.rjust(length, b"\xff")
 
 
-fpad32 = fpad(length=32)
+def fpad32(value: bytes) -> bytes:
+    return fpad(value, length=32)

--- a/tests/core/utils/test_zpad.py
+++ b/tests/core/utils/test_zpad.py
@@ -1,7 +1,12 @@
 import pytest
 
 from eth_abi.utils.padding import (
+    fpad,
+    fpad32,
     zpad,
+    zpad32,
+    zpad32_right,
+    zpad_right,
 )
 
 
@@ -16,4 +21,29 @@ from eth_abi.utils.padding import (
 )
 def test_zpadding(value, length, expected):
     actual = zpad(value, length)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "func,value,length,expected",
+    (
+        (zpad_right, b"abc", 5, b"abc\x00\x00"),
+        (fpad, b"abc", 5, b"\xff\xffabc"),
+    ),
+)
+def test_padding_helpers(func, value, length, expected):
+    actual = func(value, length)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "func,value,expected",
+    (
+        (zpad32, b"abc", (b"\x00" * 29) + b"abc"),
+        (zpad32_right, b"abc", b"abc" + (b"\x00" * 29)),
+        (fpad32, b"abc", (b"\xff" * 29) + b"abc"),
+    ),
+)
+def test_32_byte_padding_helpers(func, value, expected):
+    actual = func(value)
     assert actual == expected


### PR DESCRIPTION
### What I did

Replaced curried 32-byte padding helpers with direct wrapper functions.

fixes: #

### How I did it

`zpad`, `zpad_right`, and `fpad` still accept `(value, length)`, while `zpad32`, `zpad32_right`, and `fpad32` avoid `toolz.curry` partial dispatch.

### How to verify it

- `python -m pytest tests/core/utils/test_zpad.py`
- `tox -e py310-core`
- `tox -e py310-lint`
- Local microbench on CPython 3.12.3 vs `ethabi/main` at `afa145a`: `zpad32`, `zpad32_right`, and `fpad32` improved from 338.4 ns to 122.1 ns per 3-call iteration, -63.9%.

### Checklist

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete