### PR TITLE
perf: avoid duplicate registry lookup in is_encodable

### DIFF
--- a/eth_abi/codec.py
+++ b/eth_abi/codec.py
@@ -16,6 +16,7 @@ from eth_abi.decoding import (
 )
 from eth_abi.exceptions import (
     EncodingError,
+    MultipleEntriesFound,
 )
 from eth_abi.registry import (
     ABIRegistry,
@@ -82,20 +83,18 @@ class ABIEncoder(BaseABICoder):
         :returns: ``True`` if ``arg`` is encodable as a value of the ABI type
             ``typ``.  Otherwise, ``False``.
         """
-        if not self.is_encodable_type(typ):
+        try:
+            encoder = self._registry.get_encoder(typ)
+        except MultipleEntriesFound:
+            raise
+        except Exception:
             return False
 
-        encoder = self._registry.get_encoder(typ)
-
+        validate = getattr(encoder, "validate_value", encoder)
         try:
-            encoder.validate_value(arg)
+            validate(arg)
         except EncodingError:
             return False
-        except AttributeError:
-            try:
-                encoder(arg)
-            except EncodingError:
-                return False
 
         return True
 

--- a/tests/core/abi_tests/test_is_encodable.py
+++ b/tests/core/abi_tests/test_is_encodable.py
@@ -8,6 +8,19 @@ from hypothesis import (
 from eth_abi import (
     is_encodable,
 )
+from eth_abi.codec import (
+    ABICodec,
+)
+from eth_abi.encoding import (
+    UnsignedIntegerEncoder,
+)
+from eth_abi.exceptions import (
+    EncodingError,
+    MultipleEntriesFound,
+)
+from eth_abi.registry import (
+    registry,
+)
 from tests.core.common.strategies import (
     single_strs_values,
     tuple_strs_values,
@@ -39,6 +52,33 @@ def test_is_encodable_returns_false(type_str, python_value):
 def test_is_encodable_returns_true_for_random_valid_values(type_and_value):
     _type, value = type_and_value
     assert is_encodable(_type, value)
+
+
+def encode_null(value):
+    if value is not None:
+        raise EncodingError("Unsupported value")
+
+    return b"\x00" * 32
+
+
+def test_is_encodable_supports_callable_encoders():
+    codec = ABICodec(registry.copy())
+    codec._registry.register_encoder("null", encode_null)
+
+    assert codec.is_encodable("null", None)
+    assert not codec.is_encodable("null", 1)
+
+
+def test_is_encodable_raises_for_multiple_matching_encoders():
+    codec = ABICodec(registry.copy())
+    codec._registry.register_encoder(
+        lambda type_str: type_str == "uint256",
+        UnsignedIntegerEncoder,
+        label="uint256-duplicate",
+    )
+
+    with pytest.raises(MultipleEntriesFound):
+        codec.is_encodable("uint256", 1)
 
 
 @settings(deadline=None)


### PR DESCRIPTION
### What I did

Reduced `ABIEncoder.is_encodable()` to one registry lookup.

fixes: #

### How I did it

The method now calls `get_encoder()` directly, preserves `MultipleEntriesFound`, returns `False` for missing or invalid encoders, and validates the value with the encoder it already fetched.

### How to verify it

- `python -m pytest tests/core/abi_tests/test_is_encodable.py tests/core/abi_tests/test_is_encodable_type.py`
- `tox -e py310-core`
- `tox -e py310-lint`
- Local microbench on CPython 3.12.3 vs `ethabi/main` at `afa145a`: `ABICodec.is_encodable("uint256", 1)` improved from 319.5 ns to 291.1 ns per call, -8.9%.

### Checklist

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete