### PR TITLE
perf: cache NumberEncoder bounds per instance

### DIFF
--- a/eth_abi/encoding.py
+++ b/eth_abi/encoding.py
@@ -4,6 +4,9 @@ from collections.abc import (
     Callable,
 )
 import decimal
+from functools import (
+    cached_property,
+)
 from itertools import (
     accumulate,
 )
@@ -243,6 +246,20 @@ class NumberEncoder(Fixed32ByteSizeEncoder):
     illegal_value_fn: Callable[..., Any] | None = None
     type_check_fn: Callable[..., Any] | None = None
 
+    @cached_property
+    def bounds(self):
+        if self.bounds_fn is None:
+            raise AssertionError("`bounds_fn` is None")
+        return self.bounds_fn(self.value_bit_size)
+
+    @cached_property
+    def lower_bound(self):
+        return self.bounds[0]
+
+    @cached_property
+    def upper_bound(self):
+        return self.bounds[1]
+
     def validate(self):
         super().validate()
 
@@ -263,15 +280,12 @@ class NumberEncoder(Fixed32ByteSizeEncoder):
         if illegal_value:
             self.invalidate_value(value, exc=IllegalValue)
 
-        if self.bounds_fn is None:
-            raise AssertionError("`bounds_fn` is None")
-        lower_bound, upper_bound = self.bounds_fn(self.value_bit_size)
-        if value < lower_bound or value > upper_bound:
+        if value < self.lower_bound or value > self.upper_bound:
             self.invalidate_value(
                 value,
                 exc=ValueOutOfBounds,
                 msg=f"Cannot be encoded in {self.value_bit_size} bits. Must be bounded "
-                f"between [{lower_bound}, {upper_bound}].",
+                f"between [{self.lower_bound}, {self.upper_bound}].",
             )
 
 


### PR DESCRIPTION
### What I did

Cached per-instance numeric encoder bounds.

fixes: #

### How I did it

`NumberEncoder` now stores `bounds`, `lower_bound`, and `upper_bound` with `cached_property`, avoiding repeated bound function calls during validation.

### How to verify it

- `python -m pytest tests/core/encoding/test_encoder_properties.py tests/core/abi_tests/test_uint_properties.py`
- `tox -e py310-core`
- `tox -e py310-lint`
- Local microbench on CPython 3.12.3 vs `ethabi/main` at `afa145a`: `UnsignedIntegerEncoder.validate_value(1)` improved from 228.2 ns to 124.0 ns per call, -45.7%.

### Checklist

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete